### PR TITLE
Update Debian_Dockerfile to use Go 1.20

### DIFF
--- a/Debian_Dockerfile
+++ b/Debian_Dockerfile
@@ -1,5 +1,5 @@
 # docker build -t wolweb .
-FROM golang:buster AS builder
+FROM golang:1.20-buster AS builder
 
 LABEL org.label-schema.vcs-url="https://github.com/sameerdhoot/wolweb" \
       org.label-schema.url="https://github.com/sameerdhoot/wolweb/blob/master/README.md"
@@ -9,10 +9,8 @@ WORKDIR /wolweb
 
 # Install Dependecies
 RUN git clone https://github.com/sameerdhoot/wolweb . && \
-    go mod init wolweb && \
-    go get -d github.com/gorilla/handlers && \
-    go get -d github.com/gorilla/mux && \
-    go get -d github.com/ilyakaznacheev/cleanenv
+    go mod tidy && \
+    go mod download
 
 # Build Source Files
 RUN go build -o wolweb . 


### PR DESCRIPTION
I am proposing that we change the Go to version 1.20 based on suggestion from other PR which I merged.